### PR TITLE
Fix CanonicalRedirectService constructor for Shopware 6.7.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "scop/scopplatformredirecter",
   "description": "With the redirect plugin of the agency scope01 from frankfurt(m) (https://scope01.com/) you are able to create and manage redirects from the admin area of shopware 6",
-  "version": "v4.0.0",
+  "version": "v4.0.1",
   "type": "shopware-platform-plugin",
   "license": "MIT",
   "authors": [

--- a/src/Decorator/CanonicalRedirectServiceDecorator.php
+++ b/src/Decorator/CanonicalRedirectServiceDecorator.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\Routing\CanonicalRedirectService;
+use Shopware\Core\Framework\Script\Execution\Hook;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,9 +34,9 @@ class CanonicalRedirectServiceDecorator extends CanonicalRedirectService
      */
     private SystemConfigService $configService;
 
-    public function __construct(CanonicalRedirectService $inner, SystemConfigService $configService, EntityRepository $redirectRepository)
+    public function __construct(CanonicalRedirectService $inner, SystemConfigService $configService, EntityRepository $redirectRepository, ExtensionDispatcher $extensionDispatcher)
     {
-        parent::__construct($configService);
+        parent::__construct($configService, $extensionDispatcher);
         $this->configService = $configService;
         $this->repository = $redirectRepository;
         $this->inner = $inner;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="Scop\PlatformRedirecter\Decorator\CanonicalRedirectServiceDecorator.inner"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="scop_platform_redirecter_redirect.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
**This PR fixes a compatibility issue with Shopware 6.7.1 where the** 
CanonicalRedirectServiceDecorator
 was failing due to an ArgumentCountError.

****Problem**
In Shopware 6.7, the `CanonicalRedirectService` constructor signature was updated to require two parameters:
- `SystemConfigService $configService`
- `ExtensionDispatcher $extensionDispatcher`
The decorator was only passing one parameter (SystemConfigService), causing the following error:

```bash
Too few arguments to function Shopware\Core\Framework\Routing\CanonicalRedirectService::__construct(), 1 passed and exactly 2 expected
```
**Solution**
- Added ExtensionDispatcher import to the decorator class
- Updated the constructor to accept ExtensionDispatcher as the fourth parameter
- Modified the parent constructor call to pass both required parameters
- Updated the service definition in `services.xml` to inject the ExtensionDispatcher service
Incremented version from v4.0.0 to v4.0.1

**Changes Made**
1. **CanonicalRedirectServiceDecorator.php**:
- Added `use Shopware\Core\Framework\Extensions\ExtensionDispatcher;`
- Updated constructor signature to include `ExtensionDispatcher $extensionDispatcher`
- Fixed parent constructor call: `parent::__construct($configService, $extensionDispatcher);`
2. **services.xml**:
- Added <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/> to service definition
3. **composer.json**:
- Bumped version to v4.0.1 